### PR TITLE
Fix New Game window reset and release packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Qt on Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +48,12 @@ jobs:
           target: 'desktop'
           arch: 'clang_64'
           modules: 'qtscxml'
+
+      - name: Install Linux build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build qt6-base-dev qt6-base-dev-tools
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
@@ -86,6 +92,18 @@ jobs:
           name: Minesweeper-win64-installer.exe
           path: ${{github.workspace}}/build/Minesweeper-*-win64.exe
 
+      - name: Package Debian Installer
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: ${{github.workspace}}/build
+        run: cpack -G DEB -C ${{env.BUILD_TYPE}}
+
+      - name: Upload Debian Installer
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: minesweeper-linux-deb
+          path: ${{github.workspace}}/build/*.deb
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: build
@@ -102,6 +120,11 @@ jobs:
           name: Minesweeper-win64-installer.exe
           path: ${{ github.workspace }}
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: minesweeper-linux-deb
+          path: ${{ github.workspace }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -111,3 +134,4 @@ jobs:
           files: |
             ${{ github.workspace }}/Minesweeper-*.exe
             ${{ github.workspace }}/minesweeper.app.zip
+            ${{ github.workspace }}/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build qt6-base-dev qt6-base-dev-tools
+          sudo apt-get install -y build-essential cmake ninja-build qt6-base-dev qt6-base-dev-tools qt6-scxml-dev
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/resources/linux/minesweeper.desktop.in
+++ b/resources/linux/minesweeper.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Minesweeper
+Comment=Free Qt/C++20 Minesweeper
+Exec=minesweeper
+Icon=minesweeper
+Terminal=false
+Categories=Game;LogicGame;Qt;
+Keywords=minesweeper;game;logic;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 cmake_policy(SET CMP0087 NEW)
 configure_file(appinfo.h.in ${CMAKE_CURRENT_BINARY_DIR}/appinfo.h @ONLY NEWLINE_STYLE UNIX)
+configure_file(${CMAKE_SOURCE_DIR}/resources/linux/minesweeper.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/minesweeper.desktop @ONLY NEWLINE_STYLE UNIX)
 
 qt_add_resources(RESOURCES ../resources/resources.qrc)
 
@@ -64,8 +65,19 @@ elseif (APPLE)
 	        BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
 	        COMPONENT Runtime)
 else ()
+	set_target_properties(${PROJECT_NAME} PROPERTIES
+	                      INSTALL_RPATH ""
+	                      INSTALL_RPATH_USE_LINK_PATH FALSE
+	                      )
 	install(TARGETS ${PROJECT_NAME}
 	        RUNTIME DESTINATION bin
+	        )
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/minesweeper.desktop
+	        DESTINATION share/applications
+	        )
+	install(FILES ${CMAKE_SOURCE_DIR}/resources/images/mine.png
+	        DESTINATION share/icons/hicolor/256x256/apps
+	        RENAME minesweeper.png
 	        )
 endif (WIN32)
 
@@ -89,19 +101,29 @@ endif (WIN32)
 #	INSTALLER
 #-------------------------------------------------------------------------------
 
-set(CPACK_GENERATOR NSIS)
 set(CPACK_PACKAGE_NAME "Minesweeper")
 set(CPACK_PACKAGE_VENDOR "Menari Softworks")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Free Qt/C++17 Minesweeper")
 set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 set(CPACK_RESOURCE_FILE_README ${CMAKE_SOURCE_DIR}/README.md)
-set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/resources/icons/logo.ico")
-set(CPACK_NSIS_MUI_UNIICON "${CMAKE_SOURCE_DIR}/resources/icons/logo.ico")
-set(CPACK_NSIS_INSTALLED_ICON_NAME "bin/minesweeper.exe")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/nholthaus/minesweeper")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")
 set(CPACK_PACKAGE_EXECUTABLES "minesweeper" "minesweeper")
 set(CPACK_CREATE_DESKTOP_LINKS minesweeper)
 set(CPACK_PACKAGE_VERSION ${GIT_TAG})
+
+if (WIN32)
+	set(CPACK_GENERATOR NSIS)
+	set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/resources/icons/logo.ico")
+	set(CPACK_NSIS_MUI_UNIICON "${CMAKE_SOURCE_DIR}/resources/icons/logo.ico")
+	set(CPACK_NSIS_INSTALLED_ICON_NAME "bin/minesweeper.exe")
+elseif(UNIX AND NOT APPLE)
+	set(CPACK_GENERATOR DEB)
+	set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+	set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Nic Holthaus")
+	set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+	set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
+endif()
 
 include(CPack)

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -261,7 +261,7 @@ void GameBoard::placeMines(Tile* firstClicked)
 	emit initialized();
 }
 
-void GameBoard::setTheme(Qt::ColorScheme colorScheme)
+void GameBoard::setTheme(Theme::ColorScheme colorScheme)
 {
 	for(auto& index : m_tileIndices)
 	{

--- a/src/gameboard.h
+++ b/src/gameboard.h
@@ -4,6 +4,7 @@
 #include <QSet>
 
 #include "tile.h"
+#include "theme.h"
 
 class GameBoard : public QFrame
 {
@@ -20,7 +21,7 @@ public:
 public slots:
 
 	void placeMines(Tile* firstClicked);
-	void setTheme(Qt::ColorScheme colorScheme);
+	void setTheme(Theme::ColorScheme colorScheme);
 
 signals:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -406,12 +406,12 @@ void MainWindow::changeEvent(QEvent* event)
 {
 	if (event->type() == QEvent::ThemeChange || event->type() == QEvent::StyleChange)
 	{
-		this->setTheme(QGuiApplication::styleHints()->colorScheme());
+		this->setTheme(Theme::currentColorScheme());
 	}
 	QMainWindow::changeEvent(event);
 }
 
-void MainWindow::setTheme(Qt::ColorScheme colorScheme)
+void MainWindow::setTheme(Theme::ColorScheme colorScheme)
 {
 	gameBoard->setTheme(colorScheme);
 	mineCounter->setTheme(colorScheme);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -6,6 +6,7 @@
 #include "minetimer.h"
 #include "highScoreModel.h"
 #include "gameStats.h"
+#include "theme.h"
 
 #include <QAction>
 #include <QActionGroup>
@@ -57,7 +58,7 @@ private:
 protected:
 
 	void changeEvent(QEvent*) override;
-	void setTheme(Qt::ColorScheme colorScheme);
+	void setTheme(Theme::ColorScheme colorScheme);
 
 private:
 

--- a/src/mineCounter.cpp
+++ b/src/mineCounter.cpp
@@ -1,7 +1,4 @@
 #include "mineCounter.h"
-#include <QGuiApplication>
-#include <QStyleHints>
-
 MineCounter::MineCounter(QWidget* parent)
 	: QLCDNumber(parent)
 {
@@ -9,7 +6,7 @@ MineCounter::MineCounter(QWidget* parent)
 	this->display(0);
 	this->setSegmentStyle(QLCDNumber::Flat);
 	this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-	this->setTheme(QGuiApplication::styleHints()->colorScheme());
+	this->setTheme(Theme::currentColorScheme());
 }
 
 void MineCounter::setNumMines(int numMines)
@@ -24,9 +21,9 @@ void MineCounter::setFlagCount(unsigned int flagCount)
 	display((int)m_totalMines - (int)flagCount);
 }
 
-void MineCounter::setTheme(Qt::ColorScheme colorScheme)
+void MineCounter::setTheme(Theme::ColorScheme colorScheme)
 {
-	if (colorScheme == Qt::ColorScheme::Dark)
+	if (Theme::isDark(colorScheme))
 		this->setStyleSheet(".QLCDNumber { border: 2px inset #303030; background-color: black; color: red; }");
 	else
 		this->setStyleSheet(".QLCDNumber { border: 2px inset gray; background-color: black; color: red; }");

--- a/src/mineCounter.h
+++ b/src/mineCounter.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <QLCDNumber>
 
+#include "theme.h"
+
 class MineCounter : public QLCDNumber
 {
 public:
@@ -8,7 +10,7 @@ public:
 
 	void setNumMines(int numMines);
 	void setFlagCount(unsigned int flagCount);
-	void setTheme(Qt::ColorScheme colorScheme);
+	void setTheme(Theme::ColorScheme colorScheme);
 	virtual QSize sizeHint() const override;
 
 private:

--- a/src/minetimer.cpp
+++ b/src/minetimer.cpp
@@ -1,7 +1,4 @@
 #include "minetimer.h"
-#include <QGuiApplication>
-#include <QStyleHints>
-
 MineTimer::MineTimer(QWidget* parent /*= nullptr*/)
 	: QLCDNumber(parent)
 	, m_seconds(0)
@@ -10,7 +7,7 @@ MineTimer::MineTimer(QWidget* parent /*= nullptr*/)
 	this->display(0);
 	this->setSegmentStyle(QLCDNumber::Flat);
 	this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-	this->setTheme(QGuiApplication::styleHints()->colorScheme());
+	this->setTheme(Theme::currentColorScheme());
 }
 
 void MineTimer::incrementTime()
@@ -29,9 +26,9 @@ int MineTimer::time() const
 	return m_seconds;
 }
 
-void  MineTimer::setTheme(Qt::ColorScheme colorScheme)
+void  MineTimer::setTheme(Theme::ColorScheme colorScheme)
 {
-	if (colorScheme == Qt::ColorScheme::Dark)
+	if (Theme::isDark(colorScheme))
 		this->setStyleSheet(".QLCDNumber { border: 2px inset #303030; background-color: black; color: red; }");
 	else
 		this->setStyleSheet(".QLCDNumber { border: 2px inset gray; background-color: black; color: red; }");

--- a/src/minetimer.h
+++ b/src/minetimer.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <QLCDNumber>
 
+#include "theme.h"
+
 class MineTimer : public QLCDNumber
 {
 public:
@@ -9,7 +11,7 @@ public:
 	void incrementTime();
 	void reset();
 	int time() const;
-	void setTheme(Qt::ColorScheme colorScheme);
+	void setTheme(Theme::ColorScheme colorScheme);
 	virtual QSize sizeHint() const override;
 
 private:

--- a/src/theme.h
+++ b/src/theme.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QGuiApplication>
+#include <QPalette>
+#include <QStyleHints>
+#include <QtGlobal>
+
+namespace Theme
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+using ColorScheme = Qt::ColorScheme;
+
+inline ColorScheme currentColorScheme()
+{
+	return QGuiApplication::styleHints()->colorScheme();
+}
+
+inline bool isDark(ColorScheme colorScheme)
+{
+	return colorScheme == Qt::ColorScheme::Dark;
+}
+#else
+enum class ColorScheme
+{
+	Light,
+	Dark
+};
+
+inline ColorScheme currentColorScheme()
+{
+	return QGuiApplication::palette().color(QPalette::Window).lightness() < 128 ? ColorScheme::Dark : ColorScheme::Light;
+}
+
+inline bool isDark(ColorScheme colorScheme)
+{
+	return colorScheme == ColorScheme::Dark;
+}
+#endif
+}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -8,9 +8,6 @@
 #include <QFinalState>
 #include <QMouseEvent>
 #include <QSizePolicy>
-#include <QGuiApplication>
-#include <QStyleHints>
-
 bool Tile::m_firstClick = false;
 
 const QString Tile::unrevealedStyleSheetLight =
@@ -109,7 +106,7 @@ Tile::Tile(TileLocation location, QWidget* parent /*= nullptr*/)
 	setCheckable(true);
 	setMouseTracking(true);
 
-	this->setTheme(QGuiApplication::styleHints()->colorScheme());
+	this->setTheme(Theme::currentColorScheme());
 }
 
 Tile::~Tile()
@@ -351,7 +348,7 @@ void Tile::createStateMachine()
 void Tile::setText()
 {
 	QString color;
-	if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)
+	if (Theme::isDark(Theme::currentColorScheme()))
 	{
 		switch (m_adjacentMineCount)
 		{
@@ -421,9 +418,9 @@ void Tile::setText()
 		QPushButton::setText(QString::number(m_adjacentMineCount));
 }
 
-void Tile::setTheme(Qt::ColorScheme colorScheme)
+void Tile::setTheme(Theme::ColorScheme colorScheme)
 {
-	if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)
+	if (Theme::isDark(colorScheme))
 	{
 		unrevealedStyleSheet         = unrevealedStyleSheetDark;
 		revealedStyleSheet           = revealedStyleSheetDark;

--- a/src/tile.h
+++ b/src/tile.h
@@ -6,6 +6,8 @@
 #include <QFinalState>
 #include <QSignalMapper>
 
+#include "theme.h"
+
 struct TileLocation
 {
 	unsigned int row; 
@@ -55,7 +57,7 @@ public slots:
 	void incrementAdjacentFlaggedCount();
 	void decrementAdjacentFlaggedCount();
 	void incrementAdjacentMineCount();
-	void setTheme(Qt::ColorScheme colorScheme);
+	void setTheme(Theme::ColorScheme colorScheme);
 
 signals:
 


### PR DESCRIPTION
## Summary
- keep the main window shell stable on New Game instead of replacing the central widget
- fix Linux packaging and release automation for Windows, macOS, and Debian artifacts
- add Qt theme compatibility fallback for older system Qt builds

## Notes
- resolves the long-standing Linux disappearing window issue and equivalent Windows flashing on New Game
- Linux .deb now uses system Qt runtime dependencies and standard install paths
- release workflow now runs from tag pushes in the build workflow