### PR TITLE
fix: package a real macOS app bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
 
       - name: Install Application (macOS)
         if: matrix.os == 'macos-latest'
-        run: cmake --install ${{github.workspace}}/build
+        run: cmake --install ${{github.workspace}}/build --prefix ${{github.workspace}}/bundle
 
       - name: zip app bundle
         if: matrix.os == 'macos-latest'
-        run: ditto -c -k --sequesterRsrc --keepParent ${{github.workspace}}/build/minesweeper.app ${{github.workspace}}/build/minesweeper.app.zip
+        run: ditto -c -k --sequesterRsrc --keepParent ${{github.workspace}}/bundle/minesweeper.app ${{github.workspace}}/build/minesweeper.app.zip
 
       - name: Upload .app Bundle
         if: matrix.os == 'macos-latest'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,29 @@ cmake_policy(SET CMP0087 NEW)
 configure_file(appinfo.h.in ${CMAKE_CURRENT_BINARY_DIR}/appinfo.h @ONLY NEWLINE_STYLE UNIX)
 configure_file(${CMAKE_SOURCE_DIR}/resources/linux/minesweeper.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/minesweeper.desktop @ONLY NEWLINE_STYLE UNIX)
 
+if(APPLE)
+	set(MACOS_ICONSET_DIR ${CMAKE_CURRENT_BINARY_DIR}/minesweeper.iconset)
+	set(MACOS_BUNDLE_ICON ${CMAKE_CURRENT_BINARY_DIR}/minesweeper.icns)
+	add_custom_command(
+		OUTPUT ${MACOS_BUNDLE_ICON}
+		COMMAND ${CMAKE_COMMAND} -E rm -rf ${MACOS_ICONSET_DIR}
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${MACOS_ICONSET_DIR}
+		COMMAND sips -z 16 16 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_16x16.png
+		COMMAND sips -z 32 32 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_16x16@2x.png
+		COMMAND sips -z 32 32 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_32x32.png
+		COMMAND sips -z 64 64 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_32x32@2x.png
+		COMMAND sips -z 128 128 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_128x128.png
+		COMMAND sips -z 256 256 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_128x128@2x.png
+		COMMAND sips -z 256 256 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_256x256.png
+		COMMAND sips -z 512 512 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_256x256@2x.png
+		COMMAND sips -z 512 512 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_512x512.png
+		COMMAND sips -z 1024 1024 ${CMAKE_SOURCE_DIR}/resources/images/mine.png --out ${MACOS_ICONSET_DIR}/icon_512x512@2x.png
+		COMMAND iconutil -c icns ${MACOS_ICONSET_DIR} -o ${MACOS_BUNDLE_ICON}
+		DEPENDS ${CMAKE_SOURCE_DIR}/resources/images/mine.png
+		VERBATIM
+		)
+endif()
+
 qt_add_resources(RESOURCES ../resources/resources.qrc)
 
 qt6_add_executable(${PROJECT_NAME}
@@ -32,7 +55,12 @@ qt6_add_executable(${PROJECT_NAME}
                    ${CMAKE_CURRENT_BINARY_DIR}/appinfo.h
                    gameStatsDialog.cpp
                    gameStatsDialog.h
+                   $<$<PLATFORM_ID:Darwin>:${MACOS_BUNDLE_ICON}>
                    )
+
+if(APPLE)
+	set_source_files_properties(${MACOS_BUNDLE_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
                       Qt::Core
@@ -59,6 +87,7 @@ elseif (APPLE)
 	                      MACOSX_BUNDLE_BUNDLE_VERSION "${GIT_TAG}"
 	                      MACOSX_BUNDLE_SHORT_VERSION_STRING "${GIT_TAG}"
 	                      MACOSX_BUNDLE_GUI_IDENTIFIER "github.com/nholthaus/minesweeper"
+	                      MACOSX_BUNDLE_ICON_FILE "minesweeper.icns"
 	                      )
 	# Install the .app bundle
 	install(TARGETS ${PROJECT_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,12 +57,12 @@ elseif (APPLE)
 	set_target_properties(${PROJECT_NAME} PROPERTIES
 	                      MACOSX_BUNDLE_BUNDLE_NAME "Minesweeper"
 	                      MACOSX_BUNDLE_BUNDLE_VERSION "${GIT_TAG}"
-	                      MACOSX_BUNDLE_LONG_VERSION_STRING "${GIT_TAG}"
+	                      MACOSX_BUNDLE_SHORT_VERSION_STRING "${GIT_TAG}"
 	                      MACOSX_BUNDLE_GUI_IDENTIFIER "github.com/nholthaus/minesweeper"
 	                      )
 	# Install the .app bundle
 	install(TARGETS ${PROJECT_NAME}
-	        BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
+	        BUNDLE DESTINATION .
 	        COMPONENT Runtime)
 else ()
 	set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -89,6 +89,13 @@ include(InstallRequiredSystemLibraries)
 if (WIN32)
 	include(windeployqt)
 	windeployqt(${PROJECT_NAME})
+	qt_generate_deploy_app_script(
+			TARGET ${PROJECT_NAME}
+			OUTPUT_SCRIPT deploy_script
+			NO_UNSUPPORTED_PLATFORM_ERROR
+			)
+	install(SCRIPT ${deploy_script})
+elseif (APPLE)
 	qt_generate_deploy_app_script(
 			TARGET ${PROJECT_NAME}
 			OUTPUT_SCRIPT deploy_script


### PR DESCRIPTION
## Summary
- deploy Qt frameworks and plugins into the macOS app bundle during install
- zip the installed .app bundle from CI instead of the raw build-tree target
- generate and embed a proper .icns app icon for macOS

## Verification
- GitHub Actions build on  succeeded on macOS, Windows, and Ubuntu
- inspected the mac artifact and confirmed it contains Qt frameworks, plugins, , and 
- verified  contains  and version 
